### PR TITLE
Fix code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,4 +1,5 @@
 import requests
+import logging
 import pyotp
 from allauth.socialaccount.models import SocialAccount
 from rest_framework.decorators import action
@@ -339,7 +340,8 @@ class UserAdminManagementViewSet(viewsets.GenericViewSet, ListModelMixin):
         try:
             make_user_staff_on_auth0(user.id)
         except requests.RequestException as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            logging.error(f"Error making user staff on Auth0: {e}")
+            return Response({"detail": "An error occurred while processing your request."}, status=status.HTTP_400_BAD_REQUEST)
 
         CustomUser.objects.filter(id=user.id).update(is_staff=True, is_superuser=True)
 
@@ -361,7 +363,8 @@ class UserAdminManagementViewSet(viewsets.GenericViewSet, ListModelMixin):
         try:
             remove_user_from_staff_on_auth0(user.id)
         except requests.RequestException as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            logging.error(f"Error removing user from staff on Auth0: {e}")
+            return Response({"detail": "An error occurred while processing your request."}, status=status.HTTP_400_BAD_REQUEST)
 
         CustomUser.objects.filter(id=user.id).update(is_staff=False, is_superuser=False)
         return Response(


### PR DESCRIPTION
Fixes [https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/10](https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/10)

To fix the problem, we need to ensure that the exception details are not exposed to the end user. Instead, we should log the exception details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the return statement that exposes the exception details with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
