### PR TITLE
Fix code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework import status, viewsets
 from django.conf import settings
 from allauth.account.utils import send_email_confirmation
-
+import logging
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
@@ -311,7 +311,8 @@ class UserManagementViewSet(viewsets.GenericViewSet):
                 user_id, {"app_metadata": {"mfa_enabled": False}}, auth0_token
             )
         except requests.RequestException as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            logging.error(f"Error disabling OTP: {str(e)}")
+            return Response({"detail": "An internal error has occurred."}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(
             {"detail": "OTP disabled successfully"}, status=status.HTTP_200_OK


### PR DESCRIPTION
Fixes [https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/9](https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/9)

To fix the problem, we need to modify the code to log the detailed exception message on the server and return a generic error message to the user. This will prevent sensitive information from being exposed to end users while still allowing developers to access the detailed error information for debugging purposes.

1. Import the `logging` module to enable logging of exception messages.
2. Replace the line that returns the exception message directly to the user with a line that logs the exception message and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
