### PR TITLE
Fix code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework import status, viewsets
 from django.conf import settings
 from allauth.account.utils import send_email_confirmation
-
+import logging
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
@@ -294,7 +294,8 @@ class UserManagementViewSet(viewsets.GenericViewSet):
                 user_id, {"app_metadata": {"mfa_enabled": True}}, auth0_token
             )
         except requests.RequestException as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            logging.error("Error updating Auth0 user: %s", str(e))
+            return Response({"detail": "An internal error has occurred."}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(
             {"detail": "OTP verified successfully"}, status=status.HTTP_200_OK
@@ -311,7 +312,8 @@ class UserManagementViewSet(viewsets.GenericViewSet):
                 user_id, {"app_metadata": {"mfa_enabled": False}}, auth0_token
             )
         except requests.RequestException as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            logging.error("Error updating Auth0 user: %s", str(e))
+            return Response({"detail": "An internal error has occurred."}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response(
             {"detail": "OTP disabled successfully"}, status=status.HTTP_200_OK


### PR DESCRIPTION
Fixes [https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/8](https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/8)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the line that returns the exception message with code that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
