### PR TITLE
Fix code scanning alert no. 12: CSRF protection weakened or disabled

### DIFF
--- a/obstracts_web/settings.py
+++ b/obstracts_web/settings.py
@@ -103,7 +103,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
-    # "django.middleware.csrf.CsrfViewMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "apps.teams.middleware.TeamsMiddleware",


### PR DESCRIPTION
Fixes [https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/12](https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/12)

To fix the problem, we need to re-enable the CSRF protection middleware in the Django settings. This involves uncommenting the `django.middleware.csrf.CsrfViewMiddleware` line in the `MIDDLEWARE` list. This change will ensure that CSRF tokens are generated and validated for incoming requests, thereby protecting the application from CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
