### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/apps/obstracts_api/pagination.py
+++ b/apps/obstracts_api/pagination.py
@@ -18,10 +18,10 @@ class CustomPagination(PageNumberPagination):
         try:
             self.page = paginator.page(page_number)
         except InvalidPage as exc:
-            msg = self.invalid_page_message.format(
-                page_number=page_number, message=str(exc)
-            )
-            raise NotFound(msg)
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error(f"Invalid page request: {exc}")
+            raise NotFound("Invalid page number.")
 
         if paginator.num_pages > 1 and self.template is not None:
             # The browsable API should display pagination controls.


### PR DESCRIPTION
Fixes [https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/3](https://github.com/muchdogesec/obstracts_web_be/security/code-scanning/3)

To fix the problem, we should avoid exposing the detailed exception message to the end user. Instead, we can log the detailed exception message on the server and return a generic error message to the user. This approach ensures that developers still have access to the detailed error information for debugging purposes, while the end user only sees a generic message.

- Modify the code to log the detailed exception message using a logging mechanism.
- Return a generic error message to the user instead of the detailed exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
